### PR TITLE
feat: Add extended polyfilio domains

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4201,8 +4201,18 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://github.com/uBlockOrigin/uAssets/pull/24255
 ! https://sansec.io/research/polyfill-supply-chain-attack
 ! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
+! https://www.bleepingcomputer.com/news/security/polyfillio-bootcdn-bootcss-staticfile-attack-traced-to-1-operator/
 ||polyfill.io^$all
 ||googie-anaiytics.com^$all
+||bootcdn.net^$all
+||bootcss.com^$all
+||staticfile.net^$all
+||staticfile.org^$all
+||unionadjs.com^$all
+||xhsbpza.com^$all
+||union.macoms.la^$all
+||newcrbpc.com^$all
+
 ! https://github.com/uBlockOrigin/uAssets/pull/24272
 ! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
 ||polyfill.com^$all


### PR DESCRIPTION
### Describe the issue

According to the news article by bleepingcomputers and in line with the announcement from Google on the topic, the number of impacted CDNs by this malware campaign is even bigger.

See: https://www.bleepingcomputer.com/news/security/polyfillio-bootcdn-bootcss-staticfile-attack-traced-to-1-operator/

This will probably break a lot of stuff. But I guess it has to break.
